### PR TITLE
Added support for Realm Studio

### DIFF
--- a/iSimulator/UI/AppMenu.swift
+++ b/iSimulator/UI/AppMenu.swift
@@ -187,7 +187,7 @@ protocol AppActionableExt: AppActionable {
 extension AppActionableExt {
     
     var appPath: String? {
-        return NSWorkspace.shared.absolutePathForApplication(withBundleIdentifier: appBundleIdentifier)
+        return self.path(forBundleIdentifier: appBundleIdentifier)
     }
     
     var icon: NSImage? {
@@ -201,6 +201,10 @@ extension AppActionableExt {
     
     var isAvailable: Bool {
         return appPath != nil
+    }
+    
+    func path(forBundleIdentifier bundleIdentifier: String) -> String? {
+        return NSWorkspace.shared.absolutePathForApplication(withBundleIdentifier: bundleIdentifier)
     }
     
 }
@@ -219,14 +223,21 @@ class AppRealmAction: AppActionableExt {
     }
     var title: String = "Open Realm Database"
     var appBundleIdentifier: String = "io.realm.realmbrowser" //com.googlecode.iterm2
+    var alternativeAppBundleIdentifier: String = "io.realm.realm-studio"
     var realmPath: String?
     @objc func perform() {
-        if let path =  realmPath {
+        guard let path = realmPath else {
+            return
+        }
+        if self.path(forBundleIdentifier: self.appBundleIdentifier) != nil {
             NSWorkspace.shared.openFile(path, withApplication: "Realm Browser")
+        } else if self.path(forBundleIdentifier: self.alternativeAppBundleIdentifier) != nil {
+            NSWorkspace.shared.openFile(path, withApplication: "Realm Studio")
         }
     }
     var isAvailable: Bool {
-        return appPath != nil && realmPath != nil
+        return (appPath != nil || self.path(forBundleIdentifier: self.alternativeAppBundleIdentifier) != nil)
+            && realmPath != nil
     }
 }
 


### PR DESCRIPTION
Updated the `AppRealmAction` to support [Realm Studio](https://realm.io/products/realm-studio/) besides the [Realm Browser](https://itunes.apple.com/us/app/realm-browser/id1007457278?mt=12).

#### isAvailable
Has been updated to check if Realm Browser or Realm Studio is available

#### perform
The updated function will first checks if the `.realm` file can be opened with the Realm Browser in order to maintain the default `iSimulator` behaviour. If Realm Browser is not available the function will try to open the `.realm` file with Realm Studio.

#### Additional thoughts
Maybe splitting up `AppRealmAction` into a `AppRealmBrowserAction` and `AppRealmStudioAction` to allow an User to decide which Realm App should be started.